### PR TITLE
Modifications to support Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
 - '2.7'
+- '3.5'
 
 install:
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh

--- a/osmnet/config.py
+++ b/osmnet/config.py
@@ -14,7 +14,7 @@ def format_check(settings):
 
     valid_keys = ['logs_folder', 'log_file', 'log_console', 'log_name', 'log_filename','keep_osm_tags']
 
-    for key in settings.keys():
+    for key in list(settings.keys()):
         assert key in valid_keys, ('{} not found in list of valid configuation keys').format(key)
         assert isinstance(key,str), ('{} must be a string').format(key)
         if key == 'keep_osm_tags':

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -4,7 +4,7 @@
 # consolidate_subdivide_geometry, quadrat_cut_geometry: https://github.com/gboeing/osmnx/blob/master/osmnx/core.py
 # project_geometry, project_gdf: https://github.com/gboeing/osmnx/blob/master/osmnx/projection.py
 
-
+from __future__ import division
 from itertools import islice
 import re
 import pandas as pd

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -4,8 +4,8 @@
 # consolidate_subdivide_geometry, quadrat_cut_geometry: https://github.com/gboeing/osmnx/blob/master/osmnx/core.py
 # project_geometry, project_gdf: https://github.com/gboeing/osmnx/blob/master/osmnx/projection.py
 
-from __future__ import division
-from itertools import islice, izip
+
+from itertools import islice
 import re
 import pandas as pd
 import requests
@@ -438,7 +438,7 @@ def process_node(e):
 
     if 'tags' in e:
         if e['tags'] is not np.nan:
-            for t, v in e['tags'].items():
+            for t, v in list(e['tags'].items()):
                 if t in config.settings.keep_osm_tags:
                     node[t] = v
 
@@ -463,7 +463,7 @@ def process_way(e):
 
     if 'tags' in e:
         if e['tags'] is not np.nan:
-            for t, v in e['tags'].items():
+            for t, v in list(e['tags'].items()):
                 if t in config.settings.keep_osm_tags:
                     way[t] = v
 
@@ -591,14 +591,14 @@ def node_pairs(nodes, ways, waynodes, two_way=True):
     """
     start_time = time.time()
     def pairwise(l):
-        return izip(islice(l, 0, len(l)), islice(l, 1, None))
+        return zip(islice(l, 0, len(l)), islice(l, 1, None))
     intersections = intersection_nodes(waynodes)
     waymap = waynodes.groupby(level=0, sort=False)
     pairs = []
 
     for id, row in ways.iterrows():
         nodes_in_way = waymap.get_group(id).node_id.values
-        nodes_in_way = filter(lambda x: x in intersections, nodes_in_way)
+        nodes_in_way = [x for x in nodes_in_way if x in intersections]
 
         if len(nodes_in_way) < 2:
             # no nodes to connect in this way

--- a/osmnet/utils.py
+++ b/osmnet/utils.py
@@ -1,7 +1,7 @@
 # The following logging functions were modified from the osmnx library and used with permission from the author Geoff Boeing:
 # log, get_logger: https://github.com/gboeing/osmnx/blob/master/osmnx/utils.py
 
-from __future__ import division
+
 
 import math
 import logging as lg
@@ -93,7 +93,7 @@ def log(message, level=None, name=None, filename=None):
         sys.stdout = sys.__stdout__
 
         # convert message to ascii for proper console display in windows terminals
-        message = unicodedata.normalize('NFKD', unicode(message)).encode('ascii', errors='replace').decode()
+        message = unicodedata.normalize('NFKD', str(message)).encode('ascii', errors='replace').decode()
         print(message)
         sys.stdout = standard_out
     # otherwise print out standard statement

--- a/osmnet/utils.py
+++ b/osmnet/utils.py
@@ -1,7 +1,7 @@
 # The following logging functions were modified from the osmnx library and used with permission from the author Geoff Boeing:
 # log, get_logger: https://github.com/gboeing/osmnx/blob/master/osmnx/utils.py
 
-
+from __future__ import division
 
 import math
 import logging as lg


### PR DESCRIPTION
A couple of modifications to support the use of this library with Python3.

The only kind of regression tests that were applied are the set from Pandana that seems to be the most important library that uses this code.

It's difficult to guarantee that performance won't be impacted in the 2.x case with some of the changes done, and the same happens with quality, general testing was done but it is not very easy to guarantee exact same behavior in 2.x and 3.x.