### PR TITLE
Add continuous integration in Windows with Appveyor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 OSMnet
 ======
 
-|Build Status|
+|Build Status| |Appveyor Build Status|
 
 Tools for the extraction of OpenStreetMap (OSM) street network data.
 Intended to be used in tandem with Pandana and UrbanAccess libraries to
@@ -38,19 +38,19 @@ Installation
 ------------
 
 conda
-^^^^^^^^^^^^^
+^^^^^
 
 conda installation is forthcoming.
 
 pip
-^^^^^^^^^^^^^
+^^^
 
 OSMnet can be installed via PyPI:
 
 ``pip install osmnet``
 
 Development Installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 To install use the ``develop`` command rather than ``install``. Make sure you
 are using the latest version of the code base by using git’s ``git pull``
@@ -84,3 +84,6 @@ Related UDST libraries
 
 .. |Build Status| image:: https://travis-ci.org/UDST/osmnet.svg?branch=master
    :target: https://travis-ci.org/UDST/osmnet
+
+.. |Appveyor Build Status| image:: https://ci.appveyor.com/api/projects/status/acuoygyy3l0lqnpv/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/pksohn/osmnet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON_VERSION: 2.7
+      MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 3.5
+      MINICONDA: C:\Miniconda3
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy pandas pytest pyyaml"
+  - activate test-environment
+  - pip install geopandas Shapely pycodestyle
+  - pip install .
+
+test_script:
+  - pycodestyle osmnet
+  - py.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy pandas pytest pyyaml"
   - activate test-environment
-  - pip install geopandas shapely pycodestyle
+  - conda install -c conda-forge shapely geopandas
+  - pip install pycodestyle
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy pandas pytest pyyaml"
   - activate test-environment
-  - pip install geopandas Shapely pycodestyle
+  - pip install geopandas shapely pycodestyle
   - pip install .
 
 test_script:


### PR DESCRIPTION
Adds a config file for Appveyor and a badge to readme. 

Build instructions are nearly identical to Travis CI builds in Linux, except Shapely has to be installed from `conda-forge` to build successfully on Windows. I made geopandas install from `conda-forge` as well.