### PR TITLE
Non-universal wheels for PyPI (related to dropping Python 2.7 support)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@
 
 - Check out the copy of the code you'd like to release
 
-- Run `python setup.py sdist bdist_wheel --universal`
+- Run `python setup.py sdist bdist_wheel` (WITHOUT the `--universal` flag, since OSMnet no longer supports Python 2)
 
 - This should create a `dist` directory containing two package files -- delete any old ones before the next step
 


### PR DESCRIPTION
The last OSMnet release ended support for Python 2.7 (see PR #23). I didn't get the distribution details quite right, and in some cases Pip in py27 was still trying to install the new version. (This came up in the UrbanAccess Travis tests.)

This PR documents what was going on and corrects the release instructions. The key is that -- in addition to specifying `python_requires` in `setup.py` -- you need to build and upload a non-universal wheel file for PyPI.

### Details

Here's some more info: https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels

_Universal_ wheels imply support for both Python 2 and Python 3. You build them with 

```
python setup.py sdist bdist_wheel --universal
```

And the filenames look like `osmnet-0.1.6-py2.py3-none-any.whl`.

To make it clear that the package no longer supports Python 2, you need a _non-universal_ pure Python wheel. You build it with 

```
python setup.py sdist bdist_wheel
```

And the filename looks like `osmnet-0.1.6-py3-none-any.whl`. (If your active environment is Python 3, it creates a wheel for Python 3.)

Note that the wheels are the `bdist_wheel` part of the command -- the `sdist` part creates a tarball like `osmnet-0.1.6.tar.gz`, and we upload both to PyPI. Conda Forge uses the tarball for the conda release, and probably in some cases users install from it too.

### Resolution

Earlier today I uploaded a non-universal wheel for OSMnet v0.1.6 to PyPI, and deleted the universal one. So if you've been having problems it should be fixed now.