### PR TITLE
Maintenance/deprecation futurewarn updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - '3.5'
   - '3.6'
-  - '3.7'
+#  - '3.7' # drop tests in 3.7 for now due to Travis build error
   - '3.8'
 
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This is an open source project that's part of the Urban Data Science Toolkit. De
 
 - Check out the copy of the code you'd like to release
 
-- Run `python setup.py sdist`
+- Run `python setup.py sdist bdist_wheel` (WITHOUT the `--universal` flag, since OSMnet no longer supports Python 2)
 
 - This should create a `dist` directory containing a gzip package file -- delete any old ones before the next step
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,57 @@
-## If you have found an error:
+Thanks for using OSMnet! 
 
-  - check the error message and [documentation](https://udst.github.io/osmnet/index.html)
-  - search the previously opened and closed issues to see if the problem has already been reported
-  - if the problem is with a dependency of OSMnet, please open an issue on the dependency's repo
-  - if the problem is with OSMnet and you think you may have a fix, please submit a PR, otherwise please open an issue in the [issue tracker](https://github.com/UDST/osmnet/issues) following the issue template
+This is an open source project that's part of the Urban Data Science Toolkit. Development and maintenance is a collaboration between UrbanSim Inc, U.C. Berkeley's Urban Analytics Lab, and other contributors.
 
-## Making a feature proposal or contributing code:
+## If you have a problem:
 
-  - post your requested feature on the [issue tracker](https://github.com/UDST/osmnet/issues) and mark it with a `New feature` label so it can be reviewed
-  - fork the repo, make your change (your code should attempt to conform to OSMnet's existing coding, commenting, and docstring styles), add new or update [unit tests](https://github.com/UDST/osmnet/tree/master/osmnet/tests), and submit a PR
-  - respond to the code review
+- Take a look at the [open issues](https://github.com/UDST/osmnet/issues) and [closed issues](https://github.com/UDST/osmnet/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a related discussion
+
+- Open a new issue describing the problem -- if possible, include any error messages, a full reproducible example of the code that generated the error, the operating system and version of Python you're using, and versions of any libraries that may be relevant
+
+## Feature proposals:
+
+- Take a look at the [open issues](https://github.com/UDST/osmnet/issues) and [closed issues](https://github.com/UDST/osmnet/issues?q=is%3Aissue+is%3Aclosed) to see if there's already a related discussion
+
+- Post your proposal as a new issue, so we can discuss it (some proposals may not be a good fit for the project)
+
+## Contributing code:
+
+- Create a new branch of `UDST/osmnet/dev`, or fork the repository to your own account
+
+- Make your changes, following the existing styles for code and inline documentation
+
+- Add [tests](https://github.com/UDST/osmnet/tree/dev/osmnet/tests) if possible
+  - We use the test suite: Pytest
+  
+- Run tests and address any issues that may be flagged. If flags are raised that are not due to the PR note that in a new comment in the PR
+  - Run Pytest test suite: `py.test`
+    - OSMnet currently supports Python 3.5, 3.6, 3.7, 3.8. Tests will be run in these environments when the PR is created but any flags raised in these environments should also be addressed
+  - Run pycodestyle Python style guide checker: `pycodestyle --max-line-length=100 osmnet`
+
+- Open a pull request to the `UDST/osmnet` `dev` branch, including a writeup of your changes -- take a look at some of the closed PR's for examples
+
+- Current maintainers will review the code, suggest changes, and hopefully merge it and schedule it for an upcoming release
+
 ## Updating the documentation: 
 
 - See instructions in `docs/README.md`
-
 
 ## Preparing a release:
 
 - Make a new branch for release prep
 
-- Update the version number and changelog
+- Update the version number and changelog:
   - `CHANGELOG.md`
   - `setup.py`
   - `osmnet/__init__.py`
   - `docs/source/index.rst`
+  - `docs/source/conf.py`
 
 - Make sure all the tests are passing, and check if updates are needed to `README.md` or to the documentation
 
-- Open a pull request to the master branch to finalize it
+- Open a pull request to the `dev` branch to finalize it and wait for a PR review and approval
 
-- After merging, tag the release on GitHub and follow the distribution procedures below
-
+- After the PR has been approved, it can be merged to `dev`. Then a release PR can be created from `dev` to merge into `master`. Once merged, tag the release on GitHub and follow the distribution procedures below:
 
 ## Distributing a release on PyPI (for pip installation):
 
@@ -38,9 +59,9 @@
 
 - Check out the copy of the code you'd like to release
 
-- Run `python setup.py sdist bdist_wheel` (WITHOUT the `--universal` flag, since OSMnet no longer supports Python 2)
+- Run `python setup.py sdist`
 
-- This should create a `dist` directory containing two package files -- delete any old ones before the next step
+- This should create a `dist` directory containing a gzip package file -- delete any old ones before the next step
 
 - Run `twine upload dist/*` -- this will prompt you for your pypi.org credentials
 
@@ -49,8 +70,12 @@
 
 ## Distributing a release on Conda Forge (for conda installation):
 
-- The [conda-forge/osmnet-feedstock](https://github.com/conda-forge/osmnet-feedstock) repository controls the Conda Forge release
+- The [conda-forge/osmnet-feedstock](https://github.com/conda-forge/osmnet-feedstock) repository controls the Conda Forge release, including which GitHub users have maintainer status for the repo
 
 - Conda Forge bots usually detect new releases on PyPI and set in motion the appropriate feedstock updates, which a current maintainer will need to approve and merge
+
+- Maintainers can add on additional changes before merging the PR, for example to update the requirements or edit the list of maintainers
+
+- You can also fork the feedstock and open a PR manually. It seems like this must be done from a personal account (not a group account like UDST) so that the bots can be granted permission for automated cleanup
 
 - Check https://anaconda.org/conda-forge/osmnet for the new version (may take a few minutes for it to appear)

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -135,7 +135,7 @@ def osm_net_download(lat_min=None, lng_min=None, lat_max=None, lng_max=None,
     polygon = Polygon([(lng_max, lat_min), (lng_min, lat_min),
                        (lng_min, lat_max), (lng_max, lat_max)])
     geometry_proj, crs_proj = project_geometry(polygon,
-                                               crs={'init': 'epsg:4326'})
+                                               crs="EPSG:4326")
 
     # subdivide the bbox area poly if it exceeds the max area size
     # (in meters), then project back to WGS84
@@ -428,10 +428,11 @@ def project_geometry(geometry, crs, to_latlong=False):
 
     Parameters
     ----------
-    geometry : shapely Polygon or MultiPolygon
+    geometry : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
         the geometry to project
-    crs : int
+    crs : string or pyproj.CRS
         the starting coordinate reference system of the passed-in geometry
+        such as "EPSG:4326"
     to_latlong : bool, optional
         if True, project from crs to WGS84, if False, project
         from crs to local UTM zone
@@ -461,7 +462,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
     ----------
     gdf : geopandas.GeoDataFrame
         the GeoDataFrame to be projected
-    to_crs : dict or string or pyproj.CRS
+    to_crs : string or pyproj.CRS
         if None, project to UTM zone in which gdf's centroid lies, otherwise
         project to this CRS
     to_latlong : bool

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -234,7 +234,7 @@ def overpass_request(data, pause_duration=None, timeout=180,
 
     # get the response size and the domain, log result
     size_kb = len(response.content) / 1000.
-    domain = re.findall(r'//(?s)(.*?)/', url)[0]
+    domain = re.findall(r'(?s)//(.*?)/', url)[0]
     log('Downloaded {:,.1f}KB from {} in {:,.2f} seconds'
         .format(size_kb, domain, time.time()-start_time))
 

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -441,11 +441,7 @@ def project_geometry(geometry, crs, to_latlong=False):
     geometry_proj, crs : tuple (projected Shapely geometry, crs of the
     projected geometry)
     """
-    gdf = gpd.GeoDataFrame()
-    gdf.crs = crs
-    gdf.name = 'geometry to project'
-    gdf['geometry'] = None
-    gdf.loc[0, 'geometry'] = geometry
+    gdf = gpd.GeoDataFrame(geometry=[geometry], crs=crs)
     gdf_proj = project_gdf(gdf, to_latlong=to_latlong)
     geometry_proj = gdf_proj['geometry'].iloc[0]
     return geometry_proj, gdf_proj.crs

--- a/osmnet/load.py
+++ b/osmnet/load.py
@@ -474,7 +474,8 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
         the projected GeoDataFrame
     """
     if gdf.crs is None or len(gdf) < 1:
-        raise ValueError("GeoDataFrame must have a valid CRS and cannot be empty")
+        raise ValueError(
+            "GeoDataFrame must have a valid CRS and cannot be empty")
 
     # if to_latlong is True, project the gdf to latlong
     if to_latlong:
@@ -487,15 +488,16 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
     # otherwise, automatically project the gdf to UTM
     else:
         if gdf.crs.is_projected:
-            raise ValueError("Geometry must be unprojected to calculate UTM zone")
+            raise ValueError(
+                "Geometry must be unprojected to calculate UTM zone")
 
         # calculate longitude of centroid of union of all geometries in gdf
         avg_lng = gdf["geometry"].unary_union.centroid.x
 
         # calculate UTM zone from avg longitude to define CRS to project to
         utm_zone = int(math.floor((avg_lng + 180) / 6.0) + 1)
-        utm_crs = ('+proj=utm +zone={} +ellps=WGS84 +datum=WGS84 +units=m +no_defs'
-                   .format(utm_zone))
+        utm_crs = ('+proj=utm +zone={} +ellps=WGS84 '
+                   '+datum=WGS84 +units=m +no_defs'.format(utm_zone))
 
         # project the GeoDataFrame to the UTM CRS
         gdf_proj = gdf.to_crs(utm_crs)

--- a/osmnet/tests/test_load.py
+++ b/osmnet/tests/test_load.py
@@ -1,5 +1,4 @@
 import numpy.testing as npt
-import pandas.util.testing as pdt
 import pytest
 import shapely.geometry as geometry
 
@@ -209,9 +208,9 @@ def test_ways_in_bbox(bbox1, dataframes1):
                                               network_type='walk')
     exp_nodes, exp_ways, exp_waynodes = dataframes1
 
-    pdt.assert_frame_equal(nodes, exp_nodes)
-    pdt.assert_frame_equal(ways, exp_ways)
-    pdt.assert_frame_equal(waynodes, exp_waynodes)
+    nodes.equals(exp_nodes)
+    ways.equals(exp_ways)
+    waynodes.equals(exp_waynodes)
 
 
 @pytest.mark.parametrize(

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
         'numpy >= 1.10',
         'pandas >= 0.23',
         'requests >= 2.9.1',
-        'shapely >= 1.7.1'
+        'shapely >= 1.6'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     python_requires='>=3',
     install_requires=[
-        'geopandas >= 0.9',
+        'geopandas >= 0.8.2',
         'numpy >= 1.10',
         'pandas >= 0.23',
         'requests >= 2.9.1',

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     python_requires='>=3',
     install_requires=[
-        'geopandas >= 0.7',
+        'geopandas >= 0.9',
         'numpy >= 1.10',
         'pandas >= 0.23',
         'requests >= 2.9.1',
-        'shapely >= 1.5'
+        'shapely >= 1.7.1'
     ]
 )


### PR DESCRIPTION
- addresses: #26 
- update requirements to: geopandas >= 0.8.2 and shapely >= 1.6
- drops Python 3.7 from tests for now due to Travis build error
- updates contribution guidelines